### PR TITLE
Add lvm2 to Dockerfile package installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ ADD https://github.com/novnc/noVNC.git#v1.6.0 /usr/share/novnc
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \
-    ceph-common dmidecode genisoimage iproute2 libosinfo-bin lsscsi mdevctl ndctl nfs-common nvme-cli openssh-client ovmf python3-libvirt python3-rados python3-rbd qemu-efi-aarch64 qemu-block-extra qemu-utils sysfsutils udev util-linux swtpm swtpm-tools libtpms0
+    ceph-common dmidecode genisoimage iproute2 libosinfo-bin lsscsi mdevctl ndctl nfs-common nvme-cli openssh-client ovmf python3-libvirt \
+    python3-rados python3-rbd qemu-efi-aarch64 qemu-block-extra qemu-utils sysfsutils udev util-linux swtpm swtpm-tools libtpms0 lvm2
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF


### PR DESCRIPTION
This package provides ability to run nova-compute with LVM backend; otherwise, it fails with:
```2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager Traceback (most recent call last):
2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager   File "/var/lib/openstack/lib/python3.10/site-packages/nova/compute/manager.py", line 11232, in _update_available_resource_for_node
2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager     self.rt.update_available_resource(context, nodename,
2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager   File "/var/lib/openstack/lib/python3.10/site-packages/nova/compute/resource_tracker.py", line 911, in update_available_resource
2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager     resources = self.driver.get_available_resource(nodename)
2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager   File "/var/lib/openstack/lib/python3.10/site-packages/nova/virt/libvirt/driver.py", line 10143, in get_available_resource
2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager     disk_info_dict = self._get_local_gb_info()
2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager   File "/var/lib/openstack/lib/python3.10/site-packages/nova/virt/libvirt/driver.py", line 8364, in _get_local_gb_info
2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager     info = lvm.get_volume_group_info(
2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager   File "/var/lib/openstack/lib/python3.10/site-packages/nova/virt/libvirt/storage/lvm.py", line 92, in get_volume_group_info
2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager     out, err = nova.privsep.fs.vginfo(vg)
2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager   File "/var/lib/openstack/lib/python3.10/site-packages/oslo_privsep/priv_context.py", line 263, in _wrap
2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager     return self.channel.remote_call(name, args, kwargs,
2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager   File "/var/lib/openstack/lib/python3.10/site-packages/oslo_privsep/daemon.py", line 219, in remote_call
2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager     raise exc_type(*result[2])
2026-03-09 22:36:44.278 2787032 ERROR nova.compute.manager FileNotFoundError: [Errno 2] No such file or directory```