### PR TITLE
Install LVM2 tools for Nova local storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ADD https://github.com/novnc/noVNC.git#v1.4.0 /usr/share/novnc
 RUN <<EOF bash -xe
 apt-get update -qq
 apt-get install -qq -y --no-install-recommends \
-    ceph-common dmidecode genisoimage iproute2 libosinfo-bin lsscsi mdevctl ndctl nfs-common nvme-cli openssh-client ovmf python3-libvirt python3-rados python3-rbd qemu-efi-aarch64 qemu-block-extra qemu-utils sysfsutils udev util-linux swtpm swtpm-tools libtpms0
+    ceph-common dmidecode genisoimage iproute2 libosinfo-bin lsscsi lvm2 mdevctl ndctl nfs-common nvme-cli openssh-client ovmf python3-libvirt python3-rados python3-rbd qemu-efi-aarch64 qemu-block-extra qemu-utils sysfsutils udev util-linux swtpm swtpm-tools libtpms0
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF


### PR DESCRIPTION
## Summary

- install the `lvm2` runtime package in the Nova image

## Why

Nova's libvirt LVM image backend invokes LVM commands such as `vgs`, `lvs`, `lvcreate`, and `lvremove` through privsep. Without the package, local-LVM instance operations fail because those executables are not present in the container.

## Validation

- `git diff --check HEAD^ HEAD`
- confirmed the commit changes only the Dockerfile runtime package list
- the pull request image-build workflow will build the complete image
